### PR TITLE
PR feedback

### DIFF
--- a/pkgs/applications/graphics/ocrmypdf/default.nix
+++ b/pkgs/applications/graphics/ocrmypdf/default.nix
@@ -1,6 +1,24 @@
-{ lib, fetchFromGitHub, python3, unpaper, ghostscript, tesseract, qpdf, glibcLocales }:
-
-with python3.pkgs;
+{ lib
+, buildPythonApplication
+, fetchFromGitHub
+, unpaper
+, ghostscript
+, tesseract
+, qpdf
+, glibcLocales
+, pytest
+, pytest_xdist
+, pytestcov
+, setuptools_scm
+, pytest-helpers-namespace
+, pytestrunner
+, ruffus
+, pillow
+, reportlab
+, pypdf2
+, img2pdf
+, cffi
+}:
 
 buildPythonApplication rec {
   version = "5.4.3";
@@ -33,7 +51,7 @@ buildPythonApplication rec {
   buildInputs = [ pytest pytest_xdist pytestcov setuptools_scm pytest-helpers-namespace pytestrunner glibcLocales ];
 
   doCheck = false;
-  
+
   propagatedBuildInputs = [
     ruffus
     pillow

--- a/pkgs/development/python-modules/img2pdf/default.nix
+++ b/pkgs/development/python-modules/img2pdf/default.nix
@@ -1,6 +1,11 @@
-{ stdenv, lib, buildPythonPackage, fetchPypi, isPyPy, python3 }:
-
-with python3.pkgs;
+{ stdenv
+, lib
+, buildPythonPackage
+, fetchPypi
+, isPyPy
+, pillow
+, pdfrw
+}:
 
 buildPythonPackage rec {
   pname = "img2pdf";

--- a/pkgs/development/python-modules/pdfrw/default.nix
+++ b/pkgs/development/python-modules/pdfrw/default.nix
@@ -1,6 +1,15 @@
-{ stdenv, lib, buildPythonPackage, fetchFromGitHub, fetchPypi, isPyPy, python3, pytest, zlib }:
-
-with python3.pkgs;
+{ stdenv
+, lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchPypi
+, isPyPy
+, pytest
+, unittest2
+, reportlab
+, pycrypto
+, zlib
+}:
 
 buildPythonPackage rec {
   pname = "pdfrw";
@@ -34,7 +43,7 @@ buildPythonPackage rec {
   '';
 
   checkInputs = [ unittest2 ];
-  
+
   checkPhase = ''
     # Copy over the test pdfs and stuff to the building directory
     cp -r $static_pdfs/* "./tests/static_pdfs"

--- a/pkgs/development/python-modules/pytest_helpers_namespace/default.nix
+++ b/pkgs/development/python-modules/pytest_helpers_namespace/default.nix
@@ -1,6 +1,10 @@
-{ stdenv, lib, buildPythonPackage, fetchPypi, isPyPy, python3, pytest }:
-
-with python3.pkgs;
+{ stdenv
+, lib
+, buildPythonPackage
+, fetchPypi
+, isPyPy
+, pytest
+}:
 
 buildPythonPackage rec {
   pname = "pytest-helpers-namespace";

--- a/pkgs/development/python-modules/ruffus/default.nix
+++ b/pkgs/development/python-modules/ruffus/default.nix
@@ -1,4 +1,9 @@
-{ stdenv, lib, buildPythonPackage, fetchPypi, isPyPy, python3 }:
+{ stdenv
+, lib
+, buildPythonPackage
+, fetchPypi
+, isPyPy
+}:
 
 buildPythonPackage rec {
   pname = "ruffus";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10078,7 +10078,7 @@ with pkgs;
 
   olm = callPackage ../development/libraries/olm { };
 
-  oneko = callPackage ../applications/misc/oneko { };   
+  oneko = callPackage ../applications/misc/oneko { };
 
   oniguruma = callPackage ../development/libraries/oniguruma { };
 
@@ -15909,7 +15909,7 @@ with pkgs;
 
   notion = callPackage ../applications/window-managers/notion { };
 
-  ocrmypdf = callPackage ../applications/graphics/ocrmypdf { };
+  ocrmypdf = python3Packages.callPackage ../applications/graphics/ocrmypdf { };
 
   openshift = callPackage ../applications/networking/cluster/openshift { };
 


### PR DESCRIPTION
Don't pass python versions explicitly when called from pythonPackages.

Its better to list all dependencies in the function that returns the
derivation.

It is better to use pythonPackages.callPackage, and list python
dependencies in the arguments of the function that returns the
derivation.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

